### PR TITLE
Split delegates into required and optional

### DIFF
--- a/kapsule-core/src/main/kotlin/space/traversal/kapsule/Delegate.kt
+++ b/kapsule-core/src/main/kotlin/space/traversal/kapsule/Delegate.kt
@@ -8,9 +8,8 @@ import kotlin.reflect.KProperty
  * @param <M> Module type that injects it.
  * @param <T> Property value type.
  * @param initializer Value initializer function.
- * @param required True for required (non-null), otherwise optional (nullable).
  */
-class Delegate<in M, T>(internal val initializer: M.() -> T, internal val required: Boolean = false) {
+sealed class Delegate<in M, T>(internal val initializer: M.() -> T?) {
 
     internal var value: T? = null
 
@@ -24,14 +23,38 @@ class Delegate<in M, T>(internal val initializer: M.() -> T, internal val requir
     }
 
     /**
-     * Delegate for value reads.
+     * Delegate for required (non-null) values.
      */
-    operator fun getValue(thisRef: Any?, property: KProperty<*>) = if (required) value!! else value
+    class Required<in M, T>(initializer: M.() -> T) : Delegate<M, T>(initializer) {
+
+        /**
+         * Delegate for value reads.
+         */
+        operator fun getValue(thisRef: Any?, property: KProperty<*>) = value!!
+
+        /**
+         * Delegate for value writes.
+         */
+        operator fun setValue(thisRef: Any?, property: KProperty<*>, t: T) {
+            value = t
+        }
+    }
 
     /**
-     * Delegate for value writes.
+     * Delegate for optional (nullable) values.
      */
-    operator fun setValue(thisRef: Any?, property: KProperty<*>, t: T) {
-        value = t
+    class Optional<in M, T>(initializer: M.() -> T?) : Delegate<M, T>(initializer) {
+
+        /**
+         * Delegate for value reads.
+         */
+        operator fun getValue(thisRef: Any?, property: KProperty<*>) = value
+
+        /**
+         * Delegate for value writes.
+         */
+        operator fun setValue(thisRef: Any?, property: KProperty<*>, t: T?) {
+            value = t
+        }
     }
 }

--- a/kapsule-core/src/main/kotlin/space/traversal/kapsule/Kapsule.kt
+++ b/kapsule-core/src/main/kotlin/space/traversal/kapsule/Kapsule.kt
@@ -23,14 +23,14 @@ class Kapsule<M> {
      *
      * @param initializer Initializer function from the module context to value.
      */
-    fun <T> req(initializer: M.() -> T) = Delegate(initializer, true).apply { delegates += this }
+    fun <T> req(initializer: M.() -> T) = Delegate.Required(initializer).apply { delegates += this }
 
     /**
      * Creates and registers delegate for an optional (nullable) injectable property.
      *
      * @param initializer Initializer function from the module context to value.
      */
-    fun <T> opt(initializer: M.() -> T?) = Delegate(initializer, false).apply { delegates += this }
+    fun <T> opt(initializer: M.() -> T?) = Delegate.Optional(initializer).apply { delegates += this }
 
     /**
      * Shortcut for [req] by invoking the class like a function.

--- a/kapsule-core/src/test/kotlin/space/traversal/kapsule/DelegateTestCase.kt
+++ b/kapsule-core/src/test/kotlin/space/traversal/kapsule/DelegateTestCase.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty
 class DelegateTestCase : TestCase() {
 
     @Test fun testInitialize_required() {
-        val delegate = Delegate<RequiredModule, String>({ value }, true)
+        val delegate = Delegate.Required<RequiredModule, String> { value }
         assertEquals(null, delegate.value)
 
         listOf("one", "two").forEach { value ->
@@ -22,7 +22,7 @@ class DelegateTestCase : TestCase() {
     }
 
     @Test fun testInitialize_optional() {
-        val delegate = Delegate<OptionalModule, String?>({ value }, false)
+        val delegate = Delegate.Optional<OptionalModule, String?> { value }
         assertEquals(null, delegate.value)
 
         listOf(null, "three").forEach { value ->
@@ -33,7 +33,7 @@ class DelegateTestCase : TestCase() {
     }
 
     @Test fun testGetValue_required() {
-        val delegate = Delegate<RequiredModule, String>({ value }, true)
+        val delegate = Delegate.Required<RequiredModule, String> { value }
         val prop = Mockito.mock(KProperty::class.java)
 
         try {
@@ -49,7 +49,7 @@ class DelegateTestCase : TestCase() {
     }
 
     @Test fun testGetValue_optional() {
-        val delegate = Delegate<OptionalModule, String?>({ value }, false)
+        val delegate = Delegate.Optional<OptionalModule, String?> { value }
         val prop = Mockito.mock(KProperty::class.java)
 
         assertEquals(null, delegate.getValue(null, prop))
@@ -60,7 +60,7 @@ class DelegateTestCase : TestCase() {
     }
 
     @Test fun testSetValue_required() {
-        val delegate = Delegate<RequiredModule, String>({ value }, true)
+        val delegate = Delegate.Required<RequiredModule, String> { value }
         val prop = Mockito.mock(KProperty::class.java)
 
         listOf("test3", "test4").forEach { expected ->
@@ -70,7 +70,7 @@ class DelegateTestCase : TestCase() {
     }
 
     @Test fun testSetValue_optional() {
-        val delegate = Delegate<OptionalModule, String?>({ value }, false)
+        val delegate = Delegate.Optional<OptionalModule, String?> { value }
         val prop = Mockito.mock(KProperty::class.java)
 
         listOf("test3", null).forEach { expected ->

--- a/kapsule-core/src/test/kotlin/space/traversal/kapsule/KapsuleTestCase.kt
+++ b/kapsule-core/src/test/kotlin/space/traversal/kapsule/KapsuleTestCase.kt
@@ -12,9 +12,9 @@ class KapsuleTestCase : TestCase() {
 
     @Test fun testRequired() {
         val kap = Kapsule<MultiModule>()
-        assertEquals(true, kap.req { reqInt }.required)
-        assertEquals(true, kap<Int> { reqInt }.required)
-        assertEquals(false, kap.opt<Int?> { reqInt }.required)
+        assertTrue(kap.req { reqInt } is Delegate.Required)
+        assertTrue(kap<Int> { reqInt } is Delegate.Required)
+        assertTrue(kap.opt<Int?> { reqInt } is Delegate.Optional)
     }
 
     @Test fun testDelegates() {

--- a/samples/simple/src/main/kotlin/space/traversal/kapsule/demo/Demo.kt
+++ b/samples/simple/src/main/kotlin/space/traversal/kapsule/demo/Demo.kt
@@ -17,9 +17,9 @@ class Demo(context: Context) {
 
     private val kap = Kapsule<DemoModule>()
 
-    val firstName by kap { firstName }
+    var firstName by kap { firstName }
     val lastName by kap.opt { lastName }
-    val emails by kap.req { emails }
+    val emails by kap { emails }
 
     init {
         kap.inject(context.module)

--- a/samples/simple/src/main/kotlin/space/traversal/kapsule/demo/Demo.kt
+++ b/samples/simple/src/main/kotlin/space/traversal/kapsule/demo/Demo.kt
@@ -19,7 +19,7 @@ class Demo(context: Context) {
 
     val firstName by kap { firstName }
     val lastName by kap.opt { lastName }
-    val emails by kap { emails }
+    val emails by kap.req { emails }
 
     init {
         kap.inject(context.module)

--- a/samples/simple/src/test/kotlin/space/traversal/kapsule/demo/DemoAppTestCase.kt
+++ b/samples/simple/src/test/kotlin/space/traversal/kapsule/demo/DemoAppTestCase.kt
@@ -14,7 +14,7 @@ class DemoAppTestCase : TestCase() {
         val demo = Demo(testContext)
         assertEquals("Jane", demo.firstName)
         assertEquals("Doe", demo.lastName)
-        assertTrue(demo.emails!!.contains("jdoe@example.org"))
-        assertTrue(demo.emails!!.contains("jane@example.org"))
+        assertTrue(demo.emails.contains("jdoe@example.org"))
+        assertTrue(demo.emails.contains("jane@example.org"))
     }
 }


### PR DESCRIPTION
Value delegates can't be parametrised to support nullable and non-null values, so `Delegate` has to be split into `Required` and `Optional`.